### PR TITLE
Adds reference for missing view controller

### DIFF
--- a/iOSModuleArchitecture/Code/Modules/FirstModule/User Interface/Wireframe/FirstModuleWireframe.swift
+++ b/iOSModuleArchitecture/Code/Modules/FirstModule/User Interface/Wireframe/FirstModuleWireframe.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class FirstModuleWireframe
 {
+    weak var viewController: FirstModuleViewController!
     let FirstModuleViewControllerIdentifier = "FirstModuleViewController"
     
     init(){}
@@ -17,7 +18,9 @@ class FirstModuleWireframe
     {
         let tmpViewController = FirstModuleViewControllerromStoryboard()
 
-        RootWireframe.showViewController(tmpViewController, inWindow: window)        
+        RootWireframe.showViewController(tmpViewController, inWindow: window)
+
+        viewController = tmpViewController
     }
     
     func FirstModuleViewControllerromStoryboard() -> FirstModuleViewController


### PR DESCRIPTION
`FirstModuleWireframe` was missing a `viewController` attribute for the code to compile. References kept as `weak` since pushing it into view retains the view controller. Let me know if it needs changing. 
